### PR TITLE
Format the "make libs" step to be more noticeable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,9 +5,9 @@ This project implements a blinking LED on a Texas Instrument Tiva C microcontrol
 [Setup tutorial ](http://antoinealb.net/programming/2015/05/01/rust-on-arm-microcontroller.html)
 
 
-To compile rust libraries (only needed once):
+To compile rust libraries (only needed once) :
+    
     make libs
-
 
 To compile :
 


### PR DESCRIPTION
The "make libs' step was not boxed and highlighted
like the other command steps described. This is a minor
change, and one of preference, but I think it improves
overall readability.
